### PR TITLE
Remove YoutubeiExtractor from extractors loading process

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ new CommandKit({
 const player = new Player(client);
 await player.extractors.register(DeezerExtractor, { decryptionKey: process.env.DEEZER_KEY });
 
-await player.extractors.loadMulti([SpotifyExtractor, DeezerExtractor, YoutubeiExtractor, DefaultExtractors]);
+await player.extractors.loadMulti([SpotifyExtractor, DeezerExtractor, DefaultExtractors]);
 
 
 // Handle the event when a track starts playing


### PR DESCRIPTION
Eliminate the YoutubeiExtractor from the extractors registration to streamline the loading process.